### PR TITLE
Use rouge for source highlighting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         files: 'test/*.adoc test/**/*.adoc'
       env:
         TEST_COMMAND: |-
-          asciidoctor -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
+          asciidoctor -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
           ::set-output name=asciidoctor-artifacts::asciidoc-out
   test-html-args:
@@ -34,7 +34,7 @@ jobs:
       env:
         DATE: '+%Y-%m-%d'
         TEST_COMMAND: |-
-          asciidoctor -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a revdate=`date +%Y-%m-%d` --failure-level=ERROR test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
+          asciidoctor -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge -a revdate=`date +%Y-%m-%d` --failure-level=ERROR test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
           ::set-output name=asciidoctor-artifacts::asciidoc-out
   test-pdf:
@@ -49,7 +49,7 @@ jobs:
         format: 'pdf'
       env:
         TEST_COMMAND: |-
-          asciidoctor-pdf -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
+          asciidoctor-pdf -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
           ::set-output name=asciidoctor-artifacts::asciidoc-out
   test-pdf-args:
@@ -65,6 +65,6 @@ jobs:
         asciidoctor-args: '-a revdate=`date +%Y-%m-%d` --failure-level=ERROR'
       env:
         TEST_COMMAND: |-
-          asciidoctor-pdf -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a revdate=`date +%Y-%m-%d` --failure-level=ERROR test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
+          asciidoctor-pdf -R . -D /github/workspace/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge -a revdate=`date +%Y-%m-%d` --failure-level=ERROR test/index.adoc test/index.adoc test/subdir/subdir.adoc test/subdir/subsubdir/index.adoc test/subdir/subsubdir/subsubdir.adoc test/subdir/subsubdir/vamoose.adoc test/subdir2/subdir2.adoc
         TEST_OUTPUT: |-
           ::set-output name=asciidoctor-artifacts::asciidoc-out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2-alpine
 
-RUN gem install asciidoctor asciidoctor-pdf asciidoctor-diagram
+RUN gem install asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
 
 RUN apk add --no-cache \
       chromium \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ if [[ -z $INPUT_FILES ]]; then
   exit $EX_USAGE
 fi
 
-COMMAND=$(echo "$ASCIIDOCTOR -R . -D $GITHUB_WORKSPACE/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json" $ASCIIDOCTOR_ARGS $INPUT_FILES)
+COMMAND=$(echo "$ASCIIDOCTOR -R . -D $GITHUB_WORKSPACE/asciidoc-out -r asciidoctor-diagram -a mermaid-puppeteer-config=/mermaid/puppeteer-config.json -a source-highlighter@=rouge" $ASCIIDOCTOR_ARGS $INPUT_FILES)
 OUTPUT=
 
 echo "Running '$COMMAND'"


### PR DESCRIPTION
[Rouge](
https://docs.asciidoctor.org/asciidoctor/latest/syntax-highlighting/rouge/) is an optional source code highlighter we use in some projects.

With bb6582a commit, a [source highlighting](https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-highlighter/) for documents conversion will be set to `rouge` by default. If a document specifies its own `source-highlighter`, the document configuration will take precedence thanks to the `@` in the `-a source-highlighter@=rouge` flag we pass here.